### PR TITLE
[Feature]: PD separation supports prefix caching #12257

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/simple_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/simple_connector.py
@@ -156,7 +156,7 @@ class SimpleConnector(KVConnectorBase):
     ) -> None:
 
         input_tokens_tensor = model_input.input_tokens
-        seq_lens = model_input.attn_metadata.seq_lens
+        seq_lens = (model_input.attn_metadata.seq_lens_tensor - model_input.attn_metadata.context_lens_tensor).tolist()
         slot_mapping_flat = model_input.attn_metadata.slot_mapping.flatten()
         start_layer = model_executable.model.start_layer
         end_layer = model_executable.model.end_layer
@@ -212,7 +212,7 @@ class SimpleConnector(KVConnectorBase):
         bypass_model_exec = True
 
         input_tokens_tensor = model_input.input_tokens
-        seq_lens = model_input.attn_metadata.seq_lens
+        seq_lens = (model_input.attn_metadata.seq_lens_tensor - model_input.attn_metadata.context_lens_tensor).tolist()
         slot_mapping = model_input.attn_metadata.slot_mapping.flatten()
 
         hidden_or_intermediate_states_for_one_req = []


### PR DESCRIPTION

Increase support for prefix caching in PD
1. Sending and receiving without transmitting the full amount of KV and hidden signals
2. Resolve the issue of opening prefix caching request errors
